### PR TITLE
Docker apache configs: No cache for html files

### DIFF
--- a/client/docker/appconf.conf
+++ b/client/docker/appconf.conf
@@ -51,3 +51,7 @@ DocumentRoot /var/www/
   Options -Indexes
 </Directory>
 
+<FilesMatch "\.html$">
+Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+Header set Expires "Sun, 8 Jun 1986 08:06:00 GMT"
+</FilesMatch>

--- a/welcome/docker/appconf.conf
+++ b/welcome/docker/appconf.conf
@@ -44,4 +44,8 @@ DocumentRoot /var/www/
   Require all granted
   Options -Indexes
 </Directory>
+<FilesMatch "\.html$">
+Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+Header set Expires "Sun, 8 Jun 1986 08:06:00 GMT"
+</FilesMatch>
 


### PR DESCRIPTION
With this change, html files are no longer kept in browser cache so you no longer need to explicitly reload a page after an update of the application