### PR TITLE
Fixes #612 embed images in emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ private_key_pkcs8.pem
 JSON.md
 spieldata
 teams-api-calls.md
-.run/
 client/locale_parser.js
 PlayGroundTest.java
 spieldata

--- a/.run/BE - InviteServerApplication.run.xml
+++ b/.run/BE - InviteServerApplication.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="BE - InviteServerApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <module name="invite-server" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="invite.InviteServerApplication" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="invite.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/BE - MockProvisioningApplication.run.xml
+++ b/.run/BE - MockProvisioningApplication.run.xml
@@ -1,0 +1,9 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="BE - MockProvisioningApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <module name="provisioning-mock" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="provisioning.MockProvisioningApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/FE - Client.run.xml
+++ b/.run/FE - Client.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="FE - Client" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/client/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="dev" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/server/src/main/java/invite/mail/ImageEmbedder.java
+++ b/server/src/main/java/invite/mail/ImageEmbedder.java
@@ -14,7 +14,7 @@ public class ImageEmbedder {
 
     private static final Log LOG = LogFactory.getLog(ImageEmbedder.class);
     private static final String DEFAULT_CONTENT_TYPE = "image/png";
-    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+    static HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
     private ImageEmbedder() {
     }
@@ -41,7 +41,7 @@ public class ImageEmbedder {
         }
     }
 
-    static String toDataUrl(String contentType, byte[] body) {
+    private static String toDataUrl(String contentType, byte[] body) {
         return "data:" + contentType + ";base64," + Base64.getEncoder().encodeToString(body);
     }
 }

--- a/server/src/main/java/invite/mail/ImageEmbedder.java
+++ b/server/src/main/java/invite/mail/ImageEmbedder.java
@@ -14,7 +14,7 @@ public class ImageEmbedder {
 
     private static final Log LOG = LogFactory.getLog(ImageEmbedder.class);
     private static final String DEFAULT_CONTENT_TYPE = "image/png";
-    static HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
     private ImageEmbedder() {
     }

--- a/server/src/main/java/invite/mail/ImageEmbedder.java
+++ b/server/src/main/java/invite/mail/ImageEmbedder.java
@@ -33,12 +33,15 @@ public class ImageEmbedder {
             String contentType = response.headers()
                     .firstValue("Content-Type")
                     .orElse(DEFAULT_CONTENT_TYPE);
-            String base64Data = Base64.getEncoder().encodeToString(response.body());
 
-            return Optional.of("data:" + contentType + ";base64," + base64Data);
+            return Optional.of(toDataUrl(contentType, response.body()));
         } catch (Exception e) {
             LOG.warn(String.format("Error fetching image from %s: %s", imageUrl, e.getMessage()));
             return Optional.empty();
         }
+    }
+
+    static String toDataUrl(String contentType, byte[] body) {
+        return "data:" + contentType + ";base64," + Base64.getEncoder().encodeToString(body);
     }
 }

--- a/server/src/main/java/invite/mail/ImageEmbedder.java
+++ b/server/src/main/java/invite/mail/ImageEmbedder.java
@@ -1,0 +1,44 @@
+package invite.mail;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Base64;
+import java.util.Optional;
+
+public class ImageEmbedder {
+
+    private static final Log LOG = LogFactory.getLog(ImageEmbedder.class);
+    private static final String DEFAULT_CONTENT_TYPE = "image/png";
+    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+    private ImageEmbedder() {
+    }
+
+    /**
+     * Fetches a remote image and returns it as a data: URL for use in an HTML.
+     *
+     * @param imageUrl the absolute URL of the image to fetch
+     * @return the data: URL, or empty if the image cannot be fetched
+     */
+    public static Optional<String> fetchAsDataUrl(String imageUrl) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder().uri(URI.create(imageUrl)).build();
+            HttpResponse<byte[]> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofByteArray());
+
+            String contentType = response.headers()
+                    .firstValue("Content-Type")
+                    .orElse(DEFAULT_CONTENT_TYPE);
+            String base64Data = Base64.getEncoder().encodeToString(response.body());
+
+            return Optional.of("data:" + contentType + ";base64," + base64Data);
+        } catch (Exception e) {
+            LOG.warn(String.format("Error fetching image from %s: %s", imageUrl, e.getMessage()));
+            return Optional.empty();
+        }
+    }
+}

--- a/server/src/main/java/invite/mail/ImageEmbedder.java
+++ b/server/src/main/java/invite/mail/ImageEmbedder.java
@@ -3,6 +3,7 @@ package invite.mail;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -15,6 +16,7 @@ public class ImageEmbedder {
     private static final Log LOG = LogFactory.getLog(ImageEmbedder.class);
     private static final String DEFAULT_CONTENT_TYPE = "image/png";
     private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+    private static final int MAX_IMAGE_BYTES = 1 * 1024 * 1024; // 1 MegaByte
 
     private ImageEmbedder() {
     }
@@ -28,15 +30,35 @@ public class ImageEmbedder {
     public static Optional<String> fetchAsDataUrl(String imageUrl) {
         try {
             HttpRequest request = HttpRequest.newBuilder().uri(URI.create(imageUrl)).build();
-            HttpResponse<byte[]> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            HttpResponse<InputStream> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream());
+
+            Optional<byte[]> body = readBounded(response.body(), imageUrl);
+            if (body.isEmpty()) {
+                return Optional.empty();
+            }
 
             String contentType = response.headers()
                     .firstValue("Content-Type")
                     .orElse(DEFAULT_CONTENT_TYPE);
 
-            return Optional.of(toDataUrl(contentType, response.body()));
+            return Optional.of(toDataUrl(contentType, body.get()));
         } catch (Exception e) {
             LOG.warn(String.format("Error fetching image from %s: %s", imageUrl, e.getMessage()));
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<byte[]> readBounded(InputStream source, String imageUrl) {
+        try (InputStream in = source) {
+            byte[] bytes = in.readNBytes(MAX_IMAGE_BYTES + 1);
+            if (bytes.length > MAX_IMAGE_BYTES) {
+                LOG.warn(String.format("Image at %s exceeds maximum size of %d bytes; aborting download",
+                        imageUrl, MAX_IMAGE_BYTES));
+                return Optional.empty();
+            }
+            return Optional.of(bytes);
+        } catch (Exception e) {
+            LOG.warn(String.format("Error reading image from %s: %s", imageUrl, e.getMessage()));
             return Optional.empty();
         }
     }

--- a/server/src/main/java/invite/mail/MailBox.java
+++ b/server/src/main/java/invite/mail/MailBox.java
@@ -19,6 +19,10 @@ import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -73,7 +77,29 @@ public class MailBox {
                     .map(idp -> idp.getName())
                     .orElse(user.getSchacHomeOrganization()));
             variables.put("institutionLogoUrl", identityProvider
-                    .map(idp -> idp.getLogoUrl())
+                    .map(idp -> {
+                        String imageUrl = idp.getLogoUrl();
+                        String htmlImgSrc;
+
+                        try {
+                            HttpClient client = HttpClient.newHttpClient();
+                            HttpRequest request = HttpRequest.newBuilder().uri(URI.create(imageUrl)).build();
+                            HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+
+                            String contentType = response.headers()
+                                    .firstValue("Content-Type")
+                                    .orElse("image/png");
+
+                            String base64Data = Base64.getEncoder().encodeToString(response.body());
+
+                            htmlImgSrc = "data:" + contentType + ";base64," + base64Data;
+                        } catch (Exception e) {
+                            System.err.println("Error fetching image: " + e.getMessage());
+                            htmlImgSrc = "";
+                        }
+
+                        return htmlImgSrc;
+                    })
                     .orElse(null));
         } else {
             variables.put("institutionName", "SURF");

--- a/server/src/main/java/invite/mail/MailBox.java
+++ b/server/src/main/java/invite/mail/MailBox.java
@@ -2,11 +2,17 @@ package invite.mail;
 
 import invite.cron.IdPMetaDataResolver;
 import invite.cron.IdentityProvider;
-import invite.model.*;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.MustacheFactory;
+import invite.model.Authority;
+import invite.model.GroupedProviders;
+import invite.model.Invitation;
+import invite.model.Language;
+import invite.model.Provisionable;
+import invite.model.User;
+import invite.model.UserRole;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.SneakyThrows;
@@ -19,11 +25,11 @@ import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("unchecked")
@@ -77,29 +83,7 @@ public class MailBox {
                     .map(idp -> idp.getName())
                     .orElse(user.getSchacHomeOrganization()));
             variables.put("institutionLogoUrl", identityProvider
-                    .map(idp -> {
-                        String imageUrl = idp.getLogoUrl();
-                        String htmlImgSrc;
-
-                        try {
-                            HttpClient client = HttpClient.newHttpClient();
-                            HttpRequest request = HttpRequest.newBuilder().uri(URI.create(imageUrl)).build();
-                            HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
-
-                            String contentType = response.headers()
-                                    .firstValue("Content-Type")
-                                    .orElse("image/png");
-
-                            String base64Data = Base64.getEncoder().encodeToString(response.body());
-
-                            htmlImgSrc = "data:" + contentType + ";base64," + base64Data;
-                        } catch (Exception e) {
-                            System.err.println("Error fetching image: " + e.getMessage());
-                            htmlImgSrc = "";
-                        }
-
-                        return htmlImgSrc;
-                    })
+                    .flatMap(idp -> ImageEmbedder.fetchAsDataUrl(idp.getLogoUrl()))
                     .orElse(null));
         } else {
             variables.put("institutionName", "SURF");

--- a/server/src/test/java/invite/mail/ImageEmbedderTest.java
+++ b/server/src/test/java/invite/mail/ImageEmbedderTest.java
@@ -1,0 +1,28 @@
+package invite.mail;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ImageEmbedderTest {
+
+    @Test
+    void toDataUrl() {
+        // base64 encoding is "iVBORw0KGgo=".
+        byte[] pngBytes = {(byte) 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+
+        String dataUrl = ImageEmbedder.toDataUrl("image/png", pngBytes);
+
+        assertEquals("data:image/png;base64,iVBORw0KGgo=", dataUrl);
+    }
+
+    @Test
+    void fetchAsDataUrlReturnsEmptyOnFailure() {
+        Optional<String> dataUrl = ImageEmbedder.fetchAsDataUrl("not a url");
+
+        assertTrue(dataUrl.isEmpty());
+    }
+}

--- a/server/src/test/java/invite/mail/ImageEmbedderTest.java
+++ b/server/src/test/java/invite/mail/ImageEmbedderTest.java
@@ -1,22 +1,65 @@
 package invite.mail;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ImageEmbedderTest {
 
+    @AfterEach
+    void resetClient() {
+        ImageEmbedder.HTTP_CLIENT = HttpClient.newHttpClient();
+    }
+
     @Test
-    void toDataUrl() {
+    @SuppressWarnings("unchecked")
+    void fetchAsDataUrl() throws Exception {
+        // Given
+
         // base64 encoding is "iVBORw0KGgo=".
         byte[] pngBytes = {(byte) 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
 
-        String dataUrl = ImageEmbedder.toDataUrl("image/png", pngBytes);
+        HttpHeaders headers = HttpHeaders.of(
+                Map.of("Content-Type", List.of("image/png")),
+                (name, value) -> true);
+        HttpResponse<byte[]> response = mock(HttpResponse.class);
+        when(response.headers()).thenReturn(headers);
+        when(response.body()).thenReturn(pngBytes);
 
-        assertEquals("data:image/png;base64,iVBORw0KGgo=", dataUrl);
+        HttpClient mockClient = mock(HttpClient.class);
+        doReturn(response).when(mockClient).send(any(HttpRequest.class), any());
+        ImageEmbedder.HTTP_CLIENT = mockClient;
+
+        // When
+        Optional<String> dataUrl = ImageEmbedder.fetchAsDataUrl("http://example.com/logo.png");
+
+        // Then
+        assertTrue(dataUrl.isPresent());
+        assertEquals("data:image/png;base64,iVBORw0KGgo=", dataUrl.get());
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(mockClient).send(requestCaptor.capture(), any());
+
+        HttpRequest sentRequest = requestCaptor.getValue();
+        assertEquals(URI.create("http://example.com/logo.png"), sentRequest.uri());
+        assertEquals("GET", sentRequest.method());
     }
 
     @Test

--- a/server/src/test/java/invite/mail/ImageEmbedderTest.java
+++ b/server/src/test/java/invite/mail/ImageEmbedderTest.java
@@ -1,69 +1,44 @@
 package invite.mail;
 
-import org.junit.jupiter.api.AfterEach;
+import invite.WireMockExtension;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpHeaders;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class ImageEmbedderTest {
 
-    @AfterEach
-    void resetClient() {
-        ImageEmbedder.HTTP_CLIENT = HttpClient.newHttpClient();
-    }
+    @RegisterExtension
+    WireMockExtension mockServer = new WireMockExtension(8093);
 
     @Test
-    @SuppressWarnings("unchecked")
-    void fetchAsDataUrl() throws Exception {
-        // Given
-
-        // base64 encoding is "iVBORw0KGgo=".
+    void fetchAsDataUrl() {
+        // base64 encoding: "iVBORw0KGgo="
         byte[] pngBytes = {(byte) 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+        stubFor(get(urlPathEqualTo("/logo.png")).willReturn(aResponse()
+                .withHeader("Content-Type", "image/png")
+                .withBody(pngBytes)));
 
-        HttpHeaders headers = HttpHeaders.of(
-                Map.of("Content-Type", List.of("image/png")),
-                (name, value) -> true);
-        HttpResponse<byte[]> response = mock(HttpResponse.class);
-        when(response.headers()).thenReturn(headers);
-        when(response.body()).thenReturn(pngBytes);
+        Optional<String> dataUrl = ImageEmbedder.fetchAsDataUrl("http://localhost:8093/logo.png");
 
-        HttpClient mockClient = mock(HttpClient.class);
-        doReturn(response).when(mockClient).send(any(HttpRequest.class), any());
-        ImageEmbedder.HTTP_CLIENT = mockClient;
-
-        // When
-        Optional<String> dataUrl = ImageEmbedder.fetchAsDataUrl("http://example.com/logo.png");
-
-        // Then
         assertTrue(dataUrl.isPresent());
         assertEquals("data:image/png;base64,iVBORw0KGgo=", dataUrl.get());
-
-        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-        verify(mockClient).send(requestCaptor.capture(), any());
-
-        HttpRequest sentRequest = requestCaptor.getValue();
-        assertEquals(URI.create("http://example.com/logo.png"), sentRequest.uri());
-        assertEquals("GET", sentRequest.method());
+        verify(getRequestedFor(urlPathEqualTo("/logo.png")));
     }
 
     @Test
     void fetchAsDataUrlReturnsEmptyOnFailure() {
+        // URI.create rejects strings with whitespace, so the util's try/catch
+        // produces Optional.empty() without making any HTTP call.
         Optional<String> dataUrl = ImageEmbedder.fetchAsDataUrl("not a url");
 
         assertTrue(dataUrl.isEmpty());

--- a/server/src/test/java/invite/mail/ImageEmbedderTest.java
+++ b/server/src/test/java/invite/mail/ImageEmbedderTest.java
@@ -1,5 +1,6 @@
 package invite.mail;
 
+import com.github.tomakehurst.wiremock.http.Fault;
 import invite.WireMockExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -36,9 +37,32 @@ class ImageEmbedderTest {
     }
 
     @Test
+    void fetchAsDataUrlReturnsEmptyWhenImageExceedsMaxSize() {
+        // One byte over the 1 MB MAX_IMAGE_BYTES cap
+        byte[] oversizedBody = new byte[1024 * 1024 + 1];
+        stubFor(get(urlPathEqualTo("/huge.png")).willReturn(aResponse()
+                .withHeader("Content-Type", "image/png")
+                .withBody(oversizedBody)));
+
+        Optional<String> dataUrl = ImageEmbedder.fetchAsDataUrl("http://localhost:8093/huge.png");
+
+        assertTrue(dataUrl.isEmpty());
+        verify(getRequestedFor(urlPathEqualTo("/huge.png")));
+    }
+
+    @Test
+    void fetchAsDataUrlReturnsEmptyOnBodyReadFailure() {
+        stubFor(get(urlPathEqualTo("/broken.png")).willReturn(aResponse()
+                .withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+
+        Optional<String> dataUrl = ImageEmbedder.fetchAsDataUrl("http://localhost:8093/broken.png");
+
+        assertTrue(dataUrl.isEmpty());
+        verify(getRequestedFor(urlPathEqualTo("/broken.png")));
+    }
+
+    @Test
     void fetchAsDataUrlReturnsEmptyOnFailure() {
-        // URI.create rejects strings with whitespace, so the util's try/catch
-        // produces Optional.empty() without making any HTTP call.
         Optional<String> dataUrl = ImageEmbedder.fetchAsDataUrl("not a url");
 
         assertTrue(dataUrl.isEmpty());


### PR DESCRIPTION
This PR only handles the external content, that is the institution logo. The other 2 logos in the email are added to the email as attachment

- Includes a hardcoded limit of 1MB for the logo
- Handles malformed images: no logo will be added