### PR TITLE
Fixes #610 expiration role invite

### DIFF
--- a/.run/FE - Welcome.run.xml
+++ b/.run/FE - Welcome.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="FE - Welcome" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/welcome/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="dev" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/client/src/components/ExpandableSwitchField/ExpandableSwitchField.jsx
+++ b/client/src/components/ExpandableSwitchField/ExpandableSwitchField.jsx
@@ -1,0 +1,35 @@
+import React, {useState} from "react";
+import SwitchField from "../SwitchField";
+
+export const ExpandableSwitchField = ({
+                                          name,
+                                          label,
+                                          info,
+                                          defaultValue = false,
+                                          onChange,
+                                          disabled = false,
+                                          children
+                                      }) => {
+    const [expanded, setExpanded] = useState(defaultValue);
+
+    const toggle = () => {
+        const next = !expanded;
+        setExpanded(next);
+        if (onChange) {
+            onChange(next);
+        }
+    };
+
+    return (
+        <>
+            <SwitchField name={name}
+                         value={expanded}
+                         onChange={toggle}
+                         label={label}
+                         info={info}
+                         last={expanded}
+                         disabled={disabled}/>
+            {expanded && children}
+        </>
+    );
+};

--- a/client/src/components/ExpandableSwitchField/index.js
+++ b/client/src/components/ExpandableSwitchField/index.js
@@ -1,0 +1,1 @@
+export * from "./ExpandableSwitchField";

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -1,0 +1,1 @@
+export * from "./ExpandableSwitchField";

--- a/client/src/pages/InvitationForm.jsx
+++ b/client/src/pages/InvitationForm.jsx
@@ -29,7 +29,7 @@ import ErrorIndicator from "../components/ErrorIndicator";
 import SelectField from "../components/SelectField";
 import {DateField} from "../components/DateField";
 import EmailField from "../components/EmailField";
-import {deriveExpirationDate, futureDate} from "../utils/Date";
+import {deriveExpirationDate, displayExpiryDate, futureDate, longDateFormat} from "../utils/Date";
 import SwitchField from "../components/SwitchField";
 import {InvitationRoleCard} from "../components/InvitationRoleCard";
 import DOMPurify from "dompurify";
@@ -246,6 +246,21 @@ export const InvitationForm = () => {
 
         return isEmpty(allDefaultExpiryDates) ? futureDate(365, new Date()) :
             new Date(Math.max(...allDefaultExpiryDates.map(d => d.getTime())));
+    }
+
+    const customRoleExpiryDateInfo = () => {
+        let postfix = "Default";
+        if (customRoleExpiryDate) {
+            postfix = removeRoleBy.value === "on" ? "On" : "";
+        }
+        const expiryDate = removeRoleBy.value === "on"
+            ? invitation.roleExpiryDate
+            : futureDate(invitation.roleExpiryDays || DEFAULT_ROLE_EXPIRY_DAYS);
+        return I18n.t(`invitations.roleExpiryDateInfo${postfix}`, {
+            expiry: displayExpiryDate(expiryDate),
+            date: longDateFormat(invitation.roleExpiryDate),
+            days: DEFAULT_ROLE_EXPIRY_DAYS
+        });
     }
 
     const eduIDOnlyChanged = val => {
@@ -525,7 +540,7 @@ export const InvitationForm = () => {
                                 <ExpandableSwitchField
                                     name={"roleExpiryDate"}
                                     label={I18n.t(`invitations.roleExpiryDateQuestion`)}
-                                    info={"customRoleExpiryDateInfo()"}
+                                    info={customRoleExpiryDateInfo()}
                                     defaultValue={customRoleExpiryDate}
                                     onChange={val => setCustomRoleExpiryDate(val)}
                                 >

--- a/client/src/pages/InvitationForm.jsx
+++ b/client/src/pages/InvitationForm.jsx
@@ -34,6 +34,7 @@ import SwitchField from "../components/SwitchField";
 import {InvitationRoleCard} from "../components/InvitationRoleCard";
 import DOMPurify from "dompurify";
 import {applicationName} from "../utils/Manage";
+import {ExpandableSwitchField} from "../components";
 
 
 export const InviterContainer = ({isInviter, children}) => {
@@ -161,6 +162,7 @@ export const InvitationForm = () => {
                 intendedAuthority: isGuest ? AUTHORITIES.GUEST : AUTHORITIES.INVITER,
                 enforceEmailEquality: initialRole.enforceEmailEquality,
                 eduIDOnly: initialRole.eduIDOnly,
+                // deriveExpirationDate --> does the magic
                 roleExpiryDate: deriveExpirationDate(initialRole.isUserRole ? initialRole.role : initialRole)
             })
             setOriginalRoleId(initialRole.isUserRole ? initialRole.role.id : initialRole.id);
@@ -467,6 +469,17 @@ export const InvitationForm = () => {
                                          info={I18n.t("tooltips.eduIDOnlyTooltip")}
                                          last={invitation.eduIDOnly}
                             />
+
+                            {/* todo insert toggle here */}
+                            <h1>New Toggle here:</h1>
+                            <ExpandableSwitchField
+                                label="LabelText"
+                                info="InfoText"
+                                value={false}
+                                onChange={val => console.log(val)}
+                            >
+                                <h1>Test content</h1>
+                            </ExpandableSwitchField>
 
                             {invitation.eduIDOnly &&
                                 <SelectField

--- a/client/src/pages/InvitationForm.jsx
+++ b/client/src/pages/InvitationForm.jsx
@@ -29,13 +29,17 @@ import ErrorIndicator from "../components/ErrorIndicator";
 import SelectField from "../components/SelectField";
 import {DateField} from "../components/DateField";
 import EmailField from "../components/EmailField";
-import {deriveExpirationDate, displayExpiryDate, futureDate} from "../utils/Date";
+import {deriveExpirationDate, futureDate} from "../utils/Date";
 import SwitchField from "../components/SwitchField";
 import {InvitationRoleCard} from "../components/InvitationRoleCard";
 import DOMPurify from "dompurify";
 import {applicationName} from "../utils/Manage";
 import {ExpandableSwitchField} from "../components";
+import Select from "react-select";
 
+const DEFAULT_ROLE_EXPIRY_DAYS = 366;
+
+const removeByOptions = ["after", "on"].map(val => ({value: val, label: I18n.t(`invitations.${val}`)}))
 
 export const InviterContainer = ({isInviter, children}) => {
     return isInviter ?
@@ -57,9 +61,11 @@ export const InvitationForm = () => {
     const [roles, setRoles] = useState([]);
     const [selectedRoles, setSelectedRoles] = useState([]);
     const [originalRoleId, setOriginalRoleId] = useState(null);
+
     const [invitation, setInvitation] = useState({
         expiryDate: futureDate(30),
-        roleExpiryDate: futureDate(366),
+        roleExpiryDate: null,
+        roleExpiryDays: 0,
         invites: [],
         intendedAuthority: AUTHORITIES.GUEST
     });
@@ -73,6 +79,7 @@ export const InvitationForm = () => {
     const [acrValues, setACRValues] = useState({});
     const [language, setLanguage] = useState(I18n.locale === "en" ? languageOptions[0] : languageOptions[1]);
     const required = ["intendedAuthority", "invites"];
+    const [removeRoleBy, setRemoveRoleBy] = useState(removeByOptions[1]);
 
     const isInviter = highestAuthority(user) === AUTHORITIES.INVITER;
 
@@ -162,7 +169,6 @@ export const InvitationForm = () => {
                 intendedAuthority: isGuest ? AUTHORITIES.GUEST : AUTHORITIES.INVITER,
                 enforceEmailEquality: initialRole.enforceEmailEquality,
                 eduIDOnly: initialRole.eduIDOnly,
-                // deriveExpirationDate --> does the magic
                 roleExpiryDate: deriveExpirationDate(initialRole.isUserRole ? initialRole.role : initialRole)
             })
             setOriginalRoleId(initialRole.isUserRole ? initialRole.role.id : initialRole.id);
@@ -191,6 +197,9 @@ export const InvitationForm = () => {
         if (isValid()) {
             const invitationRequest = {
                 ...invitation,
+                roleExpiryDate: removeRoleBy.value === "after"
+                    ? futureDate(invitation.roleExpiryDays || DEFAULT_ROLE_EXPIRY_DAYS)
+                    : invitation.roleExpiryDate,
                 roleIdentifiers: selectedRoles.map(role => role.value),
                 language: language.value
             };
@@ -273,7 +282,6 @@ export const InvitationForm = () => {
                 intendedAuthority: intendedAuthority,
                 enforceEmailEquality: enforceEmailEquality,
                 eduIDOnly: eduIDOnly,
-                roleExpiryDate: defaultRoleExpiryDate(newSelectedOptions)
             })
         }
     }
@@ -412,6 +420,17 @@ export const InvitationForm = () => {
             .map(authority => ({value: authority, label: I18n.t(`access.${authority}`)}));
         const overrideSettingsAllowed = selectedRoles.every(role => role.overrideSettingsAllowed);
         const skipRoles = [AUTHORITIES.SUPER_USER, AUTHORITIES.INSTITUTION_ADMIN].includes(invitation.intendedAuthority)
+
+        const toggleRemoveBy = option => {
+            setRemoveRoleBy(option);
+
+            if (option.value === "after") {
+                setInvitation({...invitation, roleExpiryDays: DEFAULT_ROLE_EXPIRY_DAYS, roleExpiryDate: null})
+            } else {
+                setInvitation({...invitation, roleExpiryDays: 0, roleExpiryDate: futureDate(DEFAULT_ROLE_EXPIRY_DAYS)})
+            }
+        }
+
         return (
             <>
                 {isInviter &&
@@ -470,17 +489,6 @@ export const InvitationForm = () => {
                                          last={invitation.eduIDOnly}
                             />
 
-                            {/* todo insert toggle here */}
-                            <h1>New Toggle here:</h1>
-                            <ExpandableSwitchField
-                                label="LabelText"
-                                info="InfoText"
-                                value={false}
-                                onChange={val => console.log(val)}
-                            >
-                                <h1>Test content</h1>
-                            </ExpandableSwitchField>
-
                             {invitation.eduIDOnly &&
                                 <SelectField
                                     value={requestedAuthnContextOptions.find(option => option.value === invitation.requestedAuthnContext)}
@@ -506,32 +514,50 @@ export const InvitationForm = () => {
                                 />
 
                             }
+
                             {(overrideSettingsAllowed && !skipRoles) &&
-                                <SwitchField name={"roleExpiryDate"}
-                                             value={customRoleExpiryDate}
-                                             onChange={() => {
-                                                 setCustomRoleExpiryDate(!customRoleExpiryDate);
-                                                 setInvitation({
-                                                     ...invitation,
-                                                     roleExpiryDate: defaultRoleExpiryDate(selectedRoles)
-                                                 })
-                                             }}
-                                             label={I18n.t("invitations.roleExpiryDateQuestion")}
-                                             info={I18n.t("invitations.roleExpiryDateInfo", {
-                                                 expiry: displayExpiryDate(invitation.roleExpiryDate)
-                                             })}
-                                />
+                                <ExpandableSwitchField
+                                    name={"roleExpiryDate"}
+                                    label={I18n.t(`invitations.roleExpiryDateQuestion`)}
+                                    info={"customRoleExpiryDateInfo()"}
+                                    defaultValue={customRoleExpiryDate}
+                                    onChange={val => setCustomRoleExpiryDate(val)}
+                                >
+                                    <div className="role-expiry-date-container">
+                                        <p className="label">{I18n.t("invitations.removeRole")}</p>
+                                        <div className="role-expiry-date">
+                                            <Select className="input-select-inner"
+                                                    classNamePrefix={"select-inner"}
+                                                    value={removeRoleBy}
+                                                    options={removeByOptions}
+                                                    onChange={toggleRemoveBy}
+                                            />
+                                            {removeRoleBy.value === "after" &&
+                                                <>
+                                                    <InputField value={invitation.roleExpiryDays}
+                                                                isInteger={true}
+                                                                onChange={e => {
+                                                                    const val = parseInt(e.target.value);
+                                                                    const defaultExpiryDays = Number.isInteger(val) && val > 0 ? val : 1;
+                                                                    setInvitation({...invitation, roleExpiryDays: defaultExpiryDays})
+                                                                }}
+                                                                customClassName="inner-switch"/>
+                                                    <span>{I18n.t("invitations.days")}</span>
+                                                </>
+                                            }
+                                            {removeRoleBy.value === "on" &&
+                                                <DateField value={invitation.roleExpiryDate || futureDate(DEFAULT_ROLE_EXPIRY_DAYS)}
+                                                           onChange={e => setInvitation({...invitation, roleExpiryDate: e})}
+                                                           showYearDropdown={true}
+                                                           disabled={selectedRoles.some(role => !role.overrideSettingsAllowed)}
+                                                           pastDatesAllowed={config.pastDateAllowed}
+                                                           allowNull={overrideSettingsAllowed && invitation.intendedAuthority !== AUTHORITIES.GUEST}
+                                                           minDate={futureDate(1, invitation.expiryDate)}/>
+                                            }
+                                        </div>
+                                    </div>
+                                </ExpandableSwitchField>
                             }
-                            {customRoleExpiryDate &&
-                                <DateField value={invitation.roleExpiryDate}
-                                           onChange={e => setInvitation({...invitation, roleExpiryDate: e})}
-                                           showYearDropdown={true}
-                                           disabled={selectedRoles.some(role => !role.overrideSettingsAllowed)}
-                                           pastDatesAllowed={config.pastDateAllowed}
-                                           allowNull={overrideSettingsAllowed && invitation.intendedAuthority !== AUTHORITIES.GUEST}
-                                           minDate={futureDate(1, invitation.expiryDate)}
-                                           name={I18n.t("invitations.roleExpiryDate")}
-                                           toolTip={I18n.t("tooltips.roleExpiryDateTooltip")}/>}
 
                             <SwitchField name={"expiryDate"}
                                          value={customExpiryDate}

--- a/client/src/pages/InvitationForm.jsx
+++ b/client/src/pages/InvitationForm.jsx
@@ -75,6 +75,7 @@ export const InvitationForm = () => {
     const [customExpiryDate, setCustomExpiryDate] = useState(false);
     const [customRoleExpiryDate, setCustomRoleExpiryDate] = useState(false);
     const [initial, setInitial] = useState(true);
+    const [isSubmitting, setIsSubmitting] = useState(false);
     const [eduIDIdP, setEduIDIdP] = useState(null);
     const [acrValues, setACRValues] = useState({});
     const [language, setLanguage] = useState(I18n.locale === "en" ? languageOptions[0] : languageOptions[1]);
@@ -194,7 +195,8 @@ export const InvitationForm = () => {
 
     const submit = () => {
         setInitial(false);
-        if (isValid()) {
+        if (isValid() && !isSubmitting) {
+            setIsSubmitting(true);
             const invitationRequest = {
                 ...invitation,
                 roleExpiryDate: removeRoleBy.value === "after"
@@ -213,6 +215,10 @@ export const InvitationForm = () => {
                     } else {
                         navigate(-1);
                     }
+                })
+                .catch(e => {
+                    setIsSubmitting(false);
+                    throw e;
                 });
         }
     }
@@ -546,7 +552,7 @@ export const InvitationForm = () => {
                                                 </>
                                             }
                                             {removeRoleBy.value === "on" &&
-                                                <DateField value={invitation.roleExpiryDate || futureDate(DEFAULT_ROLE_EXPIRY_DAYS)}
+                                                <DateField value={invitation.roleExpiryDate}
                                                            onChange={e => setInvitation({...invitation, roleExpiryDate: e})}
                                                            showYearDropdown={true}
                                                            disabled={selectedRoles.some(role => !role.overrideSettingsAllowed)}
@@ -587,7 +593,7 @@ export const InvitationForm = () => {
                     <Button type={ButtonType.Secondary}
                             txt={I18n.t("forms.cancel")}
                             onClick={() => navigate(-1)}/>
-                    <Button disabled={disabledSubmit}
+                    <Button disabled={disabledSubmit || isSubmitting}
                             txt={I18n.t("invitations.invite")}
                             onClick={submit}/>
                 </section>

--- a/client/src/pages/InvitationForm.jsx
+++ b/client/src/pages/InvitationForm.jsx
@@ -567,12 +567,11 @@ export const InvitationForm = () => {
                                                 </>
                                             }
                                             {removeRoleBy.value === "on" &&
-                                                <DateField value={invitation.roleExpiryDate}
+                                                <DateField value={invitation.roleExpiryDate || futureDate(DEFAULT_ROLE_EXPIRY_DAYS)}
                                                            onChange={e => setInvitation({...invitation, roleExpiryDate: e})}
                                                            showYearDropdown={true}
                                                            disabled={selectedRoles.some(role => !role.overrideSettingsAllowed)}
                                                            pastDatesAllowed={config.pastDateAllowed}
-                                                           allowNull={overrideSettingsAllowed && invitation.intendedAuthority !== AUTHORITIES.GUEST}
                                                            minDate={futureDate(1, invitation.expiryDate)}/>
                                             }
                                         </div>

--- a/client/src/pages/InvitationForm.scss
+++ b/client/src/pages/InvitationForm.scss
@@ -114,6 +114,42 @@
                 margin-left: auto;
             }
         }
+
+        .role-expiry-date-container {
+            grid-column-start: first;
+            display: flex;
+            flex-direction: column;
+            border-bottom: 1px solid var(--sds--color--gray--200);
+            padding-bottom: 15px;
+
+            p.label {
+                font-weight: 600;
+                margin: 12px var(--sds--space--1) 0 0;
+            }
+
+            .role-expiry-date {
+                display: flex;
+                gap: 15px;
+                align-items: center;
+
+                .input-select-inner {
+                    width: 150px;
+
+                    .select-inner__control {
+                        height: 48px;
+                    }
+                }
+
+                .date-field {
+                    margin-top: 0;
+                }
+            }
+
+            div.input-field.inner-switch {
+                padding-bottom: 0;
+                border-bottom: none;
+            }
+        }
     }
 
 

--- a/client/src/pages/RoleForm.jsx
+++ b/client/src/pages/RoleForm.jsx
@@ -32,6 +32,7 @@ import {dateFromEpoch, displayExpiryDate, futureDate, longDateFormat} from "../u
 import DOMPurify from "dompurify";
 import WarningIndicator from "../components/WarningIndicator";
 import {DateField} from "../components/DateField";
+import {ExpandableSwitchField} from "../components";
 
 const DEFAULT_EXPIRY_DAYS = 365;
 const CUT_OFF_DELETED_USER = 5;
@@ -508,6 +509,50 @@ export const RoleForm = () => {
                              info={I18n.t("tooltips.eduIDOnlyTooltip")}
                 />
 
+                <ExpandableSwitchField
+                    label="LabelText"
+                    info="InfoText"
+                    value={false}
+                    onChange={val => console.log(val)}
+                >
+                    <div className="role-expiry-date-container">
+                        <p className="label">{I18n.t("invitations.removeRole")}</p>
+                        <div className="role-expiry-date">
+                            <Select className="input-select-inner"
+                                    classNamePrefix={"select-inner"}
+                                    value={removeRoleBy}
+                                    options={removeByOptions}
+                                    onChange={toggleRemoveBy}
+                            />
+                            {removeRoleBy.value === "after" &&
+                                <>
+                                    <InputField value={role.defaultExpiryDays || DEFAULT_EXPIRY_DAYS}
+                                                isInteger={true}
+                                                onChange={e => {
+                                                    const val = parseInt(e.target.value);
+                                                    const defaultExpiryDays = Number.isInteger(val) && val > 0 ? val : 0;
+                                                    setRole(
+                                                        {...role, defaultExpiryDays: defaultExpiryDays})
+                                                }}
+                                                customClassName="inner-switch"/>
+                                    <span>{I18n.t("invitations.days")}</span>
+                                </>
+                            }
+                            {removeRoleBy.value === "on" &&
+                                <DateField value={role.defaultExpiryDate || futureDate(365, new Date())}
+                                           onChange={e => setRole({...role, defaultExpiryDate: e})}
+                                           showYearDropdown={true}
+                                           pastDatesAllowed={config.pastDateAllowed}
+                                           allowNull={false}
+                                           minDate={futureDate(1, new Date())}
+                                />
+                            }
+
+                        </div>
+                    </div>
+                </ExpandableSwitchField>
+
+                {/* Todo: old toggle, can be removed before opening a PR */}
                 <SwitchField name={"roleExpiryDate"}
                              value={customRoleExpiryDate}
                              onChange={() => {
@@ -562,6 +607,7 @@ export const RoleForm = () => {
                         </div>
                     </div>
                 }
+                {/* ---- Todo: remove till here ----*/}
 
                 {(!initial && removeRoleBy.value === "after" && (isEmpty(role.defaultExpiryDays) || role.defaultExpiryDays < 1)) &&
                     <ErrorIndicator msg={I18n.t("forms.required", {

--- a/client/src/pages/RoleForm.jsx
+++ b/client/src/pages/RoleForm.jsx
@@ -510,10 +510,21 @@ export const RoleForm = () => {
                 />
 
                 <ExpandableSwitchField
-                    label="LabelText"
-                    info="InfoText"
-                    value={false}
-                    onChange={val => console.log(val)}
+                    name={"roleExpiryDate"}
+                    label={I18n.t(`invitations.roleExpiryDateQuestion`)}
+                    info={customRoleExpiryDateInfo()}
+                    defaultValue={customRoleExpiryDate}
+                    onChange={val => {
+                        if (!val) {
+                            setRole({
+                                ...role,
+                                defaultExpiryDays: DEFAULT_EXPIRY_DAYS,
+                                defaultExpiryDate: null
+                            });
+                            setRemoveRoleBy(removeByOptions[0]);
+                        }
+                        setCustomRoleExpiryDate(val);
+                    }}
                 >
                     <div className="role-expiry-date-container">
                         <p className="label">{I18n.t("invitations.removeRole")}</p>
@@ -553,60 +564,60 @@ export const RoleForm = () => {
                 </ExpandableSwitchField>
 
                 {/* Todo: old toggle, can be removed before opening a PR */}
-                <SwitchField name={"roleExpiryDate"}
-                             value={customRoleExpiryDate}
-                             onChange={() => {
-                                 if (customRoleExpiryDate) {
-                                     setRole({
-                                         ...role,
-                                         defaultExpiryDays: DEFAULT_EXPIRY_DAYS,
-                                         defaultExpiryDate: null
-                                     });
-                                     setRemoveRoleBy(removeByOptions[0]);
-                                 }
-                                 setCustomRoleExpiryDate(!customRoleExpiryDate);
-                             }}
-                             label={I18n.t(`invitations.roleExpiryDateQuestion`)}
-                             info={customRoleExpiryDateInfo()}
-                             last={customRoleExpiryDate}
-                />
-                {customRoleExpiryDate &&
-                    <div className="role-expiry-date-container">
-                        <p className="label">{I18n.t("invitations.removeRole")}</p>
-                        <div className="role-expiry-date">
-                            <Select className="input-select-inner"
-                                    classNamePrefix={"select-inner"}
-                                    value={removeRoleBy}
-                                    options={removeByOptions}
-                                    onChange={toggleRemoveBy}
-                            />
-                            {removeRoleBy.value === "after" &&
-                                <>
-                                    <InputField value={role.defaultExpiryDays || DEFAULT_EXPIRY_DAYS}
-                                                isInteger={true}
-                                                onChange={e => {
-                                                    const val = parseInt(e.target.value);
-                                                    const defaultExpiryDays = Number.isInteger(val) && val > 0 ? val : 0;
-                                                    setRole(
-                                                        {...role, defaultExpiryDays: defaultExpiryDays})
-                                                }}
-                                                customClassName="inner-switch"/>
-                                    <span>{I18n.t("invitations.days")}</span>
-                                </>
-                            }
-                            {removeRoleBy.value === "on" &&
-                                <DateField value={role.defaultExpiryDate || futureDate(365, new Date())}
-                                           onChange={e => setRole({...role, defaultExpiryDate: e})}
-                                           showYearDropdown={true}
-                                           pastDatesAllowed={config.pastDateAllowed}
-                                           allowNull={false}
-                                           minDate={futureDate(1, new Date())}
-                                />
-                            }
+                {/*<SwitchField name={"roleExpiryDate"}*/}
+                {/*             value={customRoleExpiryDate}*/}
+                {/*             onChange={() => {*/}
+                {/*                 if (customRoleExpiryDate) {*/}
+                {/*                     setRole({*/}
+                {/*                         ...role,*/}
+                {/*                         defaultExpiryDays: DEFAULT_EXPIRY_DAYS,*/}
+                {/*                         defaultExpiryDate: null*/}
+                {/*                     });*/}
+                {/*                     setRemoveRoleBy(removeByOptions[0]);*/}
+                {/*                 }*/}
+                {/*                 setCustomRoleExpiryDate(!customRoleExpiryDate);*/}
+                {/*             }}*/}
+                {/*             label={I18n.t(`invitations.roleExpiryDateQuestion`)}*/}
+                {/*             info={customRoleExpiryDateInfo()}*/}
+                {/*             last={customRoleExpiryDate}*/}
+                {/*/>*/}
+                {/*{customRoleExpiryDate &&*/}
+                {/*    <div className="role-expiry-date-container">*/}
+                {/*        <p className="label">{I18n.t("invitations.removeRole")}</p>*/}
+                {/*        <div className="role-expiry-date">*/}
+                {/*            <Select className="input-select-inner"*/}
+                {/*                    classNamePrefix={"select-inner"}*/}
+                {/*                    value={removeRoleBy}*/}
+                {/*                    options={removeByOptions}*/}
+                {/*                    onChange={toggleRemoveBy}*/}
+                {/*            />*/}
+                {/*            {removeRoleBy.value === "after" &&*/}
+                {/*                <>*/}
+                {/*                    <InputField value={role.defaultExpiryDays || DEFAULT_EXPIRY_DAYS}*/}
+                {/*                                isInteger={true}*/}
+                {/*                                onChange={e => {*/}
+                {/*                                    const val = parseInt(e.target.value);*/}
+                {/*                                    const defaultExpiryDays = Number.isInteger(val) && val > 0 ? val : 0;*/}
+                {/*                                    setRole(*/}
+                {/*                                        {...role, defaultExpiryDays: defaultExpiryDays})*/}
+                {/*                                }}*/}
+                {/*                                customClassName="inner-switch"/>*/}
+                {/*                    <span>{I18n.t("invitations.days")}</span>*/}
+                {/*                </>*/}
+                {/*            }*/}
+                {/*            {removeRoleBy.value === "on" &&*/}
+                {/*                <DateField value={role.defaultExpiryDate || futureDate(365, new Date())}*/}
+                {/*                           onChange={e => setRole({...role, defaultExpiryDate: e})}*/}
+                {/*                           showYearDropdown={true}*/}
+                {/*                           pastDatesAllowed={config.pastDateAllowed}*/}
+                {/*                           allowNull={false}*/}
+                {/*                           minDate={futureDate(1, new Date())}*/}
+                {/*                />*/}
+                {/*            }*/}
 
-                        </div>
-                    </div>
-                }
+                {/*        </div>*/}
+                {/*    </div>*/}
+                {/*}*/}
                 {/* ---- Todo: remove till here ----*/}
 
                 {(!initial && removeRoleBy.value === "after" && (isEmpty(role.defaultExpiryDays) || role.defaultExpiryDays < 1)) &&

--- a/client/src/pages/RoleForm.jsx
+++ b/client/src/pages/RoleForm.jsx
@@ -563,63 +563,6 @@ export const RoleForm = () => {
                     </div>
                 </ExpandableSwitchField>
 
-                {/* Todo: old toggle, can be removed before opening a PR */}
-                {/*<SwitchField name={"roleExpiryDate"}*/}
-                {/*             value={customRoleExpiryDate}*/}
-                {/*             onChange={() => {*/}
-                {/*                 if (customRoleExpiryDate) {*/}
-                {/*                     setRole({*/}
-                {/*                         ...role,*/}
-                {/*                         defaultExpiryDays: DEFAULT_EXPIRY_DAYS,*/}
-                {/*                         defaultExpiryDate: null*/}
-                {/*                     });*/}
-                {/*                     setRemoveRoleBy(removeByOptions[0]);*/}
-                {/*                 }*/}
-                {/*                 setCustomRoleExpiryDate(!customRoleExpiryDate);*/}
-                {/*             }}*/}
-                {/*             label={I18n.t(`invitations.roleExpiryDateQuestion`)}*/}
-                {/*             info={customRoleExpiryDateInfo()}*/}
-                {/*             last={customRoleExpiryDate}*/}
-                {/*/>*/}
-                {/*{customRoleExpiryDate &&*/}
-                {/*    <div className="role-expiry-date-container">*/}
-                {/*        <p className="label">{I18n.t("invitations.removeRole")}</p>*/}
-                {/*        <div className="role-expiry-date">*/}
-                {/*            <Select className="input-select-inner"*/}
-                {/*                    classNamePrefix={"select-inner"}*/}
-                {/*                    value={removeRoleBy}*/}
-                {/*                    options={removeByOptions}*/}
-                {/*                    onChange={toggleRemoveBy}*/}
-                {/*            />*/}
-                {/*            {removeRoleBy.value === "after" &&*/}
-                {/*                <>*/}
-                {/*                    <InputField value={role.defaultExpiryDays || DEFAULT_EXPIRY_DAYS}*/}
-                {/*                                isInteger={true}*/}
-                {/*                                onChange={e => {*/}
-                {/*                                    const val = parseInt(e.target.value);*/}
-                {/*                                    const defaultExpiryDays = Number.isInteger(val) && val > 0 ? val : 0;*/}
-                {/*                                    setRole(*/}
-                {/*                                        {...role, defaultExpiryDays: defaultExpiryDays})*/}
-                {/*                                }}*/}
-                {/*                                customClassName="inner-switch"/>*/}
-                {/*                    <span>{I18n.t("invitations.days")}</span>*/}
-                {/*                </>*/}
-                {/*            }*/}
-                {/*            {removeRoleBy.value === "on" &&*/}
-                {/*                <DateField value={role.defaultExpiryDate || futureDate(365, new Date())}*/}
-                {/*                           onChange={e => setRole({...role, defaultExpiryDate: e})}*/}
-                {/*                           showYearDropdown={true}*/}
-                {/*                           pastDatesAllowed={config.pastDateAllowed}*/}
-                {/*                           allowNull={false}*/}
-                {/*                           minDate={futureDate(1, new Date())}*/}
-                {/*                />*/}
-                {/*            }*/}
-
-                {/*        </div>*/}
-                {/*    </div>*/}
-                {/*}*/}
-                {/* ---- Todo: remove till here ----*/}
-
                 {(!initial && removeRoleBy.value === "after" && (isEmpty(role.defaultExpiryDays) || role.defaultExpiryDays < 1)) &&
                     <ErrorIndicator msg={I18n.t("forms.required", {
                         attribute: I18n.t("roles.defaultExpiryDays").toLowerCase()

--- a/client/src/utils/Date.js
+++ b/client/src/utils/Date.js
@@ -28,7 +28,7 @@ export const shortDateFromEpoch = (epoch, needsMultiplier = true) => {
     return dateTimeFormat.format(new Date(needsMultiplier ? epoch * 1000 : epoch));
 }
 
-const longFormatOptions = {month: "long", weekday: "long", year: "numeric"};
+const longFormatOptions = {weekday: "long", day: "numeric", month: "long", year: "numeric"};
 
 export const longDateFormat = date => {
     if (isEmpty(date)) {

--- a/client/src/utils/Date.js
+++ b/client/src/utils/Date.js
@@ -4,8 +4,9 @@ import {isEmpty} from "./Utils";
 
 let timeAgoInitialized = false;
 
-export const futureDate = (daysAhead, fromDate = new Date()) => {
-    const time = fromDate.getTime() + (1000 * 60 * 60 * 24 * daysAhead);
+export const futureDate = (daysAhead, fromDate) => {
+    const baseDate = isEmpty(fromDate) ? new Date() : fromDate;
+    const time = baseDate.getTime() + (1000 * 60 * 60 * 24 * daysAhead);
     return new Date(time);
 }
 

--- a/server/src/main/java/invite/api/InvitationOperations.java
+++ b/server/src/main/java/invite/api/InvitationOperations.java
@@ -15,7 +15,6 @@ import invite.security.UserPermissions;
 import invite.validation.EmailFormatValidator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;
@@ -25,6 +24,7 @@ import java.time.Instant;
 import java.time.Period;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;
 
@@ -140,19 +140,23 @@ public class InvitationOperations {
     }
 
     public static Instant calculateInvitationExpiry(List<Role> requestedRoles) {
-        Integer defaultExpiryDays = requestedRoles.stream()
-                .filter(role -> role.getDefaultExpiryDays() != null)
-                .max(Comparator.comparingInt(Role::getDefaultExpiryDays))
-                .map(Role::getDefaultExpiryDays)
-                .orElse(0);
         Instant now = Instant.now();
-        Instant defaultExpiryDate = requestedRoles.stream()
+
+        Optional<Instant> expiryByDays = requestedRoles.stream()
+                .filter(role -> role.getDefaultExpiryDays() != null && role.getDefaultExpiryDays() > 0)
+                .map(Role::getDefaultExpiryDays)
+                .min(Comparator.naturalOrder())
+                .map(days -> now.plus(days, ChronoUnit.DAYS));
+
+        Optional<Instant> expiryByDate = requestedRoles.stream()
                 .filter(role -> role.getDefaultExpiryDate() != null)
-                .max(Comparator.comparing(Role::getDefaultExpiryDate))
                 .map(Role::getDefaultExpiryDate)
+                .min(Comparator.naturalOrder());
+
+        return Stream.of(expiryByDays, expiryByDate)
+                .flatMap(Optional::stream)
+                .min(Comparator.naturalOrder())
                 .orElse(now);
-        Instant expiryByDays = now.plus(defaultExpiryDays, ChronoUnit.DAYS);
-        return expiryByDays.isAfter(defaultExpiryDate) ? expiryByDays : defaultExpiryDate;
     }
 
     public ResponseEntity<Map<String, Integer>> resendInvitation(Long id,

--- a/server/src/test/java/invite/api/InvitationOperationsTest.java
+++ b/server/src/test/java/invite/api/InvitationOperationsTest.java
@@ -25,7 +25,7 @@ class InvitationOperationsTest {
     }
 
     @Test
-    void longestByDays() {
+    void shortestByDays() {
         Instant before = Instant.now();
         List<Role> roles = List.of(
                 roleWithExpiryDays(5),
@@ -35,11 +35,11 @@ class InvitationOperationsTest {
 
         Instant result = InvitationOperations.calculateInvitationExpiry(roles);
 
-        assertExpiryInDays(before, result, 90);
+        assertExpiryInDays(before, result, 5);
     }
 
     @Test
-    void longestByDate() {
+    void shortestByDate() {
         Instant soon = Instant.now().plus(3, ChronoUnit.DAYS);
         Instant later = Instant.now().plus(60, ChronoUnit.DAYS);
         List<Role> roles = List.of(
@@ -49,12 +49,12 @@ class InvitationOperationsTest {
 
         Instant result = InvitationOperations.calculateInvitationExpiry(roles);
 
-        assertEquals(later, result);
+        assertEquals(soon, result);
     }
 
     @Test
-    void dateWinsWhenLaterThanDays() {
-        Instant dateExpiry = Instant.now().plus(60, ChronoUnit.DAYS);
+    void dateWinsWhenEarlierThanDays() {
+        Instant dateExpiry = Instant.now().plus(3, ChronoUnit.DAYS);
         List<Role> roles = List.of(
                 roleWithExpiryDays(7),
                 roleWithExpiryDate(dateExpiry)
@@ -62,23 +62,23 @@ class InvitationOperationsTest {
 
         Instant result = InvitationOperations.calculateInvitationExpiry(roles);
 
-        // The dateExpiry (60 days from now) is later than 7 days
+        // The dateExpiry (3 days from now) is earlier than 7 days
         assertEquals(dateExpiry, result);
     }
 
     @Test
-    void daysWinsWhenLaterThanDate() {
+    void daysWinsWhenEarlierThanDate() {
         Instant before = Instant.now();
         Instant dateExpiry = Instant.now().plus(3, ChronoUnit.DAYS);
         List<Role> roles = List.of(
-                roleWithExpiryDays(60),
+                roleWithExpiryDays(1),
                 roleWithExpiryDate(dateExpiry)
         );
 
         Instant result = InvitationOperations.calculateInvitationExpiry(roles);
 
-        // The dateExpiry (3 days from now) is later than 60 days
-        assertExpiryInDays(before, result, 60);
+        // The 1 day of expiration is earlier than dateExpiry (3 days from now)
+        assertExpiryInDays(before, result, 1);
     }
 
     @Test
@@ -88,6 +88,19 @@ class InvitationOperationsTest {
                 new Role(),
                 roleWithExpiryDate(dateExpiry),
                 new Role()
+        );
+
+        Instant result = InvitationOperations.calculateInvitationExpiry(roles);
+
+        assertEquals(dateExpiry, result);
+    }
+
+    @Test
+    void rolesWithZeroDaysAreIgnored() {
+        Instant dateExpiry = Instant.now().plus(45, ChronoUnit.DAYS);
+        List<Role> roles = List.of(
+                roleWithExpiryDays(0),
+                roleWithExpiryDate(dateExpiry)
         );
 
         Instant result = InvitationOperations.calculateInvitationExpiry(roles);

--- a/server/src/test/java/invite/api/InvitationOperationsTest.java
+++ b/server/src/test/java/invite/api/InvitationOperationsTest.java
@@ -1,0 +1,132 @@
+package invite.api;
+
+import invite.model.Role;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InvitationOperationsTest {
+
+    private Role roleWithExpiryDays(Integer days) {
+        Role role = new Role();
+        role.setDefaultExpiryDays(days);
+        return role;
+    }
+
+    private Role roleWithExpiryDate(Instant date) {
+        Role role = new Role();
+        role.setDefaultExpiryDate(date);
+        return role;
+    }
+
+    @Test
+    void longestByDays() {
+        Instant before = Instant.now();
+        List<Role> roles = List.of(
+                roleWithExpiryDays(5),
+                roleWithExpiryDays(90),
+                roleWithExpiryDays(30)
+        );
+
+        Instant result = InvitationOperations.calculateInvitationExpiry(roles);
+
+        assertExpiryInDays(before, result, 90);
+    }
+
+    @Test
+    void longestByDate() {
+        Instant soon = Instant.now().plus(3, ChronoUnit.DAYS);
+        Instant later = Instant.now().plus(60, ChronoUnit.DAYS);
+        List<Role> roles = List.of(
+                roleWithExpiryDate(soon),
+                roleWithExpiryDate(later)
+        );
+
+        Instant result = InvitationOperations.calculateInvitationExpiry(roles);
+
+        assertEquals(later, result);
+    }
+
+    @Test
+    void dateWinsWhenLaterThanDays() {
+        Instant dateExpiry = Instant.now().plus(60, ChronoUnit.DAYS);
+        List<Role> roles = List.of(
+                roleWithExpiryDays(7),
+                roleWithExpiryDate(dateExpiry)
+        );
+
+        Instant result = InvitationOperations.calculateInvitationExpiry(roles);
+
+        // The dateExpiry (60 days from now) is later than 7 days
+        assertEquals(dateExpiry, result);
+    }
+
+    @Test
+    void daysWinsWhenLaterThanDate() {
+        Instant before = Instant.now();
+        Instant dateExpiry = Instant.now().plus(3, ChronoUnit.DAYS);
+        List<Role> roles = List.of(
+                roleWithExpiryDays(60),
+                roleWithExpiryDate(dateExpiry)
+        );
+
+        Instant result = InvitationOperations.calculateInvitationExpiry(roles);
+
+        // The dateExpiry (3 days from now) is later than 60 days
+        assertExpiryInDays(before, result, 60);
+    }
+
+    @Test
+    void rolesWithoutDaysFallBackToZeroSoDateWins() {
+        Instant dateExpiry = Instant.now().plus(45, ChronoUnit.DAYS);
+        List<Role> roles = List.of(
+                new Role(),
+                roleWithExpiryDate(dateExpiry),
+                new Role()
+        );
+
+        Instant result = InvitationOperations.calculateInvitationExpiry(roles);
+
+        assertEquals(dateExpiry, result);
+    }
+
+    @Test
+    void noConstraintsFallsBackToNow() {
+        Instant before = Instant.now();
+        List<Role> roles = List.of(
+                new Role(),
+                new Role()
+        );
+
+        Instant result = InvitationOperations.calculateInvitationExpiry(roles);
+
+        Instant after = Instant.now();
+        assertTrue(!result.isBefore(before) && !result.isAfter(after),
+                "Expected expiry to fall back to ~now");
+    }
+
+    @Test
+    void emptyRolesFallsBackToNow() {
+        Instant before = Instant.now();
+        List<Role> roles = List.of();
+
+        Instant result = InvitationOperations.calculateInvitationExpiry(roles);
+
+        Instant after = Instant.now();
+        // Preventing flaky tests where result could be equals to before or after
+        assertTrue(!result.isBefore(before) && !result.isAfter(after),
+                "Expected expiry to fall back to ~now");
+    }
+
+    private void assertExpiryInDays(Instant before, Instant result, int expectedDays) {
+        Instant lowerBound = before.plus(expectedDays, ChronoUnit.DAYS);
+        Instant upperBound = Instant.now().plus(expectedDays, ChronoUnit.DAYS);
+        assertTrue(!result.isBefore(lowerBound) && !result.isAfter(upperBound),
+                String.format("Expected expiry ~%d days from now but was %s", expectedDays, result));
+    }
+}


### PR DESCRIPTION
- Adding the feature to specify the number of days the user can have a role, similar to the role configuration

- This PR includes a fix where multiple roles with different expiration dates the most restrictive expriation is picked instead of the date. Example: Role 1 (1 jan 2027) and Role 2 (1 jan 2028). The old situation picked 1 jan 2028 for both roles when combined in 1 invitation. The new situation picks 1 jan 2027. In case the user wants to specify per role: send 2 invitations

Also fixes: https://github.com/OpenConext/OpenConext-Invite/issues/743